### PR TITLE
Add support for syntax tree keys

### DIFF
--- a/src/Compilers/Core/Portable/Compilation/Compilation.cs
+++ b/src/Compilers/Core/Portable/Compilation/Compilation.cs
@@ -133,16 +133,8 @@ namespace Microsoft.CodeAnalysis
             EmitOptions? emitOptions = null,
             DeterministicKeyOptions options = DeterministicKeyOptions.Default)
         {
-            var keyBuilder = compilationOptions.CreateDeterministicKeyBuilder();
-            return keyBuilder.GetKey(
-                compilationOptions,
-                syntaxTrees,
-                references,
-                additionalTexts.NullToEmpty(),
-                analyzers.NullToEmpty(),
-                generators.NullToEmpty(),
-                emitOptions,
-                options);
+            return DeterministicKey.GetDeterministicKey(
+                compilationOptions, syntaxTrees, references, additionalTexts, analyzers, generators, emitOptions, options);
         }
 
         internal string GetDeterministicKey(

--- a/src/Compilers/Core/Portable/Compilation/DeterministicKey.cs
+++ b/src/Compilers/Core/Portable/Compilation/DeterministicKey.cs
@@ -1,0 +1,96 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Collections.Immutable;
+using System.Threading;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Emit;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Microsoft.CodeAnalysis
+{
+    internal abstract class SyntaxTreeKey
+    {
+        public abstract string FilePath { get; }
+        public abstract ParseOptions Options { get; }
+
+        protected SyntaxTreeKey()
+        {
+        }
+
+        public abstract SourceText GetText(CancellationToken cancellationToken = default);
+
+        public static SyntaxTreeKey Create(SyntaxTree tree)
+            => new DefaultSyntaxTreeKey(tree);
+
+        private sealed class DefaultSyntaxTreeKey : SyntaxTreeKey
+        {
+            private readonly SyntaxTree _tree;
+
+            public DefaultSyntaxTreeKey(SyntaxTree tree)
+            {
+                _tree = tree;
+            }
+
+            public override string FilePath
+                => _tree.FilePath;
+
+            public override ParseOptions Options
+                => _tree.Options;
+
+            public override SourceText GetText(CancellationToken cancellationToken = default)
+                => _tree.GetText(cancellationToken);
+        }
+    }
+
+    internal static class DeterministicKey
+    {
+        public static string GetDeterministicKey(
+            CompilationOptions compilationOptions,
+            ImmutableArray<SyntaxTree> syntaxTrees,
+            ImmutableArray<MetadataReference> references,
+            ImmutableArray<AdditionalText> additionalTexts = default,
+            ImmutableArray<DiagnosticAnalyzer> analyzers = default,
+            ImmutableArray<ISourceGenerator> generators = default,
+            EmitOptions? emitOptions = null,
+            DeterministicKeyOptions options = DeterministicKeyOptions.Default,
+            CancellationToken cancellationToken = default)
+        {
+            return GetDeterministicKey(
+                compilationOptions,
+                syntaxTrees.SelectAsArray(static t => SyntaxTreeKey.Create(t)),
+                references,
+                additionalTexts,
+                analyzers,
+                generators,
+                emitOptions,
+                options,
+                cancellationToken);
+        }
+
+        public static string GetDeterministicKey(
+            CompilationOptions compilationOptions,
+            ImmutableArray<SyntaxTreeKey> syntaxTrees,
+            ImmutableArray<MetadataReference> references,
+            ImmutableArray<AdditionalText> additionalTexts = default,
+            ImmutableArray<DiagnosticAnalyzer> analyzers = default,
+            ImmutableArray<ISourceGenerator> generators = default,
+            EmitOptions? emitOptions = null,
+            DeterministicKeyOptions options = DeterministicKeyOptions.Default,
+            CancellationToken cancellationToken = default)
+        {
+            var keyBuilder = compilationOptions.CreateDeterministicKeyBuilder();
+            return keyBuilder.GetKey(
+                compilationOptions,
+                syntaxTrees,
+                references,
+                additionalTexts.NullToEmpty(),
+                analyzers.NullToEmpty(),
+                generators.NullToEmpty(),
+                emitOptions,
+                options,
+                cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
Three major changes:

1. cancellation threaded through
2. ability to get full key without realizing syntaxtrees (a new SyntaxTreeKey serves that purpose)
3. Moved to a DeterministicKey static class entrypoint since it felt slightly weird for everything to be the same but to need just the additional SyntaxTreeKey type.  

The third part is def optional.  It just felt nicer to me.  
